### PR TITLE
Update runners with latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
-        if: matrix.os == 'ubuntu-22.04'
+        if: matrix.os == 'ubuntu-24.04'
         with:
           name: nupkg
           path: ./artifacts/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,17 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
           - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-22.04-arm
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - windows-2019
           - windows-2022
+          - windows-2025
 
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@
 ### Updated
 
 - Build and test on macOS 14
+- Build and test on macOS 15
+- Build and test on Ubuntu 22.04 ARM
 - Build and test on Ubuntu 24.04
-- No longer built and tested on macOS 11 due to GitHub Actions [no longer supporting](https://github.com/actions/runner-images/issues/9255) that version
+- Build and test on Ubuntu 24.04 ARM
+- Build and test on Windows 2025
+- No longer built and tested on macOS 11 & 12 due to GitHub Actions [no longer supporting](https://github.com/actions/runner-images/issues/9255) those versions
 
 ## [0.2.0](https://github.com/xt0rted/dotnet-rimraf/compare/v0.1.0...v0.2.0) - 2024-04-10
 


### PR DESCRIPTION
- Removes `macos-12` since it's no longer available
- Added `macos-15`
- Added `ubuntu-22.04-arm`
- Added `ubuntu-24.04-arm`
- Added `windows-2025`